### PR TITLE
Further binary size optimizations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   draft_release:
+    name: Draft release
     runs-on: ubuntu-latest
     steps:
-    - name: Create Draft Release
+    - name: Create draft release
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -66,7 +67,7 @@ jobs:
     - name: Compile binary
       run: xargo build --release --target ${{ matrix.target_triplet }}
       env:
-        RUSTFLAGS: '-Z strip=symbols'
+        RUSTFLAGS: '-Z strip=symbols --cfg custom_abort'
     - name: Upload release assets
       uses: actions/upload-release-asset@v1
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "console",
+ "libc",
  "miniserde",
  "minreq",
  "pico-args",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "console",
+ "miniserde",
  "minreq",
  "pico-args",
- "serde",
  "thiserror",
 ]
 
@@ -135,14 +135,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-internal"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3fb39c72c84ffbed14f8ee8b1a0e52ecd323df2ee69499fd3400a95d7269aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniserde"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e021d8031f6e224438f402d4c59d26c997e6e13498bd34da1aa1f858bd3b2f43"
+dependencies = [
+ "itoa",
+ "mini-internal",
+ "ryu",
+]
+
+[[package]]
 name = "minreq"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781e56f7d29192378f0a04948b1e6aec67ce561273b2dd26ac510bbe88d7be70"
 dependencies = [
  "native-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -348,37 +368,6 @@ checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ miniserde = "0.1"
 minreq = { version = "2", features = ["https-native"] }
 anyhow = "1"
 thiserror = "1"
+libc = "0.2"
 
 [profile.release]
 opt-level = 'z'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 pico-args = "0.4"
 console = "0.14"
-serde = { version = "1", features = ["derive"] }
-minreq = { version = "2", features = ["https-native", "json-using-serde"] }
+miniserde = "0.1"
+minreq = { version = "2", features = ["https-native"] }
 anyhow = "1"
 thiserror = "1"
 

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,2 +1,2 @@
 [dependencies]
-std = { default-features = false }
+std = { default-features = false, features = ["panic_immediate_abort"] }

--- a/src/abort_handler.rs
+++ b/src/abort_handler.rs
@@ -1,17 +1,24 @@
-use libc::{c_int, c_void, sighandler_t, signal, SIGABRT, SIGILL};
+use libc::{c_int, c_void, sighandler_t};
 
 extern "C" fn handler(_: c_int) {
     eprintln!("Abort: Unexpected error.");
     std::process::exit(127);
 }
 
+#[allow(unused)]
 fn get_handler() -> sighandler_t {
-    handler as extern "C" fn(c_int) as *mut c_void as sighandler_t
+    handler as *mut c_void as sighandler_t
 }
 
 pub fn setup() {
+    #[cfg(unix)]
     unsafe {
-        signal(SIGABRT, get_handler());
-        signal(SIGILL, get_handler());
+        use libc::{sigaction, sigemptyset, sigset_t, SIGABRT, SIGILL};
+        use std::{mem, ptr};
+        let mut descriptor: sigaction = mem::zeroed();
+        descriptor.sa_sigaction = get_handler();
+        sigemptyset(&mut descriptor.sa_mask as *mut sigset_t);
+        sigaction(SIGABRT, &mut descriptor as *mut sigaction, ptr::null_mut());
+        sigaction(SIGILL, &mut descriptor as *mut sigaction, ptr::null_mut());
     }
 }

--- a/src/abort_handler.rs
+++ b/src/abort_handler.rs
@@ -1,0 +1,17 @@
+use libc::{c_int, c_void, sighandler_t, signal, SIGABRT, SIGILL};
+
+extern "C" fn handler(_: c_int) {
+    eprintln!("Abort: Unexpected error.");
+    std::process::exit(127);
+}
+
+fn get_handler() -> sighandler_t {
+    handler as extern "C" fn(c_int) as *mut c_void as sighandler_t
+}
+
+pub fn setup() {
+    unsafe {
+        signal(SIGABRT, get_handler());
+        signal(SIGILL, get_handler());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,12 @@ use ui::Ui;
 #[cfg(test)]
 mod test;
 
+#[cfg(custom_abort)]
+mod abort_handler;
+
 fn main() -> anyhow::Result<()> {
+    #[cfg(custom_abort)]
+    abort_handler::setup();
     let command = Command::from_command_line()?;
     let api = CsesHttpApi::default();
     let storage = FileStorage::default();


### PR DESCRIPTION
 - Switch to miniserde
 - Use "panic_immediate_abort" from the binary size optimization [guide](https://github.com/johnthagen/min-sized-rust)

Upon panic, there is no formatting. I've tried to add a generic message to be printed in `abort_handler.rs`.

On Linux & macOS, this should be printed when a panic occurs: (macOS untested so far)

```
Abort: Unexpected error.
```

On Windows, the abort caused by panics cannot be caught through the libc API. This means nothing might be printed on panic, which can be very misleading to the user. It would be necessary to use Windows APIs to improve this, and maybe this can be done later.

Test builds available [here](https://github.com/H4m5t3r/cses-cli/releases/tag/v0.0.3-test)