### PR TITLE
Add error printing function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,7 @@ mod test;
 
 #[cfg(custom_abort)]
 mod abort_handler;
-
-fn main() -> anyhow::Result<()> {
+fn run() -> anyhow::Result<()> {
     #[cfg(custom_abort)]
     abort_handler::setup();
     let command = Command::from_command_line()?;
@@ -41,4 +40,11 @@ fn main() -> anyhow::Result<()> {
     let mut ui = Ui::with_resources(resources);
     ui.run(command)?;
     Ok(())
+}
+
+fn main() {
+    if let Err(err) = run() {
+        ui::print_error(&err);
+        std::process::exit(1);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,6 @@
 mod login;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use console::Term;
 
 use crate::command::HELP_STR;
@@ -33,4 +33,8 @@ impl<R: ResourcesProvider> Ui<R> {
         }
         Ok(())
     }
+}
+
+pub fn print_error(err: &Error) {
+    println!("{:?}", err);
 }


### PR DESCRIPTION
    Previously anyhow errors were being returned from main

    Add separate function for error formatting and printing

    Set program return code to 1 if an error was detected