### PR TITLE
Avoid console::measure_text_width

### DIFF
--- a/src/ui/submission.rs
+++ b/src/ui/submission.rs
@@ -57,8 +57,8 @@ fn print_status(ui: &mut Ui<impl RP>, submission_info: &SubmissionInfo) -> Resul
             test_progress.finished_tests as f64 / test_progress.total_tests as f64;
         if (0.0..=1.0).contains(&progress_fraction) {
             let (_r, term_width) = ui.term.size();
-            let mut text_width = console::measure_text_width(status_text) as u64;
-            text_width += console::measure_text_width(&submission_info.status) as u64;
+            let mut text_width = status_text.chars().count() as u64;
+            text_width += submission_info.status.chars().count() as u64;
             text_width += 4;
             let bar_width = (term_width as u64).saturating_sub(text_width);
             let progress_bar = progress_bar(bar_width, progress_fraction)?;


### PR DESCRIPTION
The function uses regexes internally to strip ANSI codes, which pulls all regex machinery into the binary. Binary size was almost 1 MB.

Measuring unicode codepoints should be fine - we just  need to avoid measuring styled text.