### PR TITLE
Submission without task id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -32,9 +32,9 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f57fec1ac7e4de72dcc69811795f1a7172ed06012f80a5d1ee651b62484f588"
+checksum = "a88b6bd5df287567ffdf4ddf4d33060048e1068308e5f62d81c6f9824a045a48"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -52,9 +52,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
  "cc",
@@ -87,12 +87,6 @@ dependencies = [
  "memchr",
  "regex-automata",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -325,10 +319,11 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781e56f7d29192378f0a04948b1e6aec67ce561273b2dd26ac510bbe88d7be70"
+checksum = "7439d8f140e38812d07ccec2ac34c28f494e0e50074b402969d2a6b9d37d84a3"
 dependencies = [
+ "log",
  "native-tls",
 ]
 
@@ -406,9 +401,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -451,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7afeb98c5a10e0bffcc7fc16e105b04d06729fac5fd6384aebf7ff5cb5a67d"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pkg-config"
@@ -576,12 +574,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -622,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -635,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/api/mock_server/app.py
+++ b/api/mock_server/app.py
@@ -66,7 +66,7 @@ def submissions_post(token_info, course_id, task):
     if submission_id is None:
         return ({"message": f"Invalid submission: {details}",
                  "code": "client_error"}, 400)
-    return ({"id": submission_id, "task_id": task}, 200)
+    return ({"submission_id": submission_id, "task_id": task}, 200)
 
 
 def get_submission(token_info, course_id, submission_id, poll=False):

--- a/api/mock_server/app.py
+++ b/api/mock_server/app.py
@@ -69,15 +69,14 @@ def submissions_post(token_info, course_id, task_id):
     return ({"id": submission_id}, 200)
 
 
-def get_submission(token_info, course_id, task_id, submission_id, poll=False):
+def get_submission(token_info, course_id, submission_id, poll=False):
     print(f"get submit: {token_info}")
     print(f"course_id: {course_id}")
-    print(f"task_id: {task_id}")
     print(f"submission_id: {submission_id}")
     print(f"poll: {poll}")
     if not integration and poll:
         time.sleep(1.5)
-    submission_info = state.get_submission_info(course_id, task_id,
+    submission_info = state.get_submission_info(course_id,
                                                 submission_id)
     if submission_info is None:
         return ({"message": "Submission not found",

--- a/api/mock_server/app.py
+++ b/api/mock_server/app.py
@@ -17,7 +17,7 @@ from werkzeug.exceptions import MethodNotAllowed
 
 from server_state import ServerState
 from submission import NewSubmission
-from scenarios import scenarios
+from scenarios import scenarios, DEFAULT_TASK
 
 
 integration = False
@@ -52,7 +52,7 @@ def logout_post(token_info):
     return (NoContent, 204)
 
 
-def submissions_post(token_info, course_id, task):
+def submissions_post(token_info, course_id, task=DEFAULT_TASK):
     details = connexion.request.json
     try:
         details["content"] = base64.b64decode(details["content"]) \

--- a/api/mock_server/app.py
+++ b/api/mock_server/app.py
@@ -52,7 +52,7 @@ def logout_post(token_info):
     return (NoContent, 204)
 
 
-def submissions_post(token_info, course_id, task_id):
+def submissions_post(token_info, course_id, task):
     details = connexion.request.json
     try:
         details["content"] = base64.b64decode(details["content"]) \
@@ -61,12 +61,12 @@ def submissions_post(token_info, course_id, task_id):
         return ({"message": "Could not decode the content with base64",
                  "code": "client_error"}, 400)
 
-    new_submission = NewSubmission(course_id, task_id, connexion.request.json)
+    new_submission = NewSubmission(course_id, task, connexion.request.json)
     submission_id = state.add_submission(new_submission)
     if submission_id is None:
         return ({"message": f"Invalid submission: {details}",
                  "code": "client_error"}, 400)
-    return ({"id": submission_id}, 200)
+    return ({"id": submission_id, "task_id": task}, 200)
 
 
 def get_submission(token_info, course_id, submission_id, poll=False):

--- a/api/mock_server/scenarios.py
+++ b/api/mock_server/scenarios.py
@@ -13,6 +13,30 @@ CPP_CODE = {
     "filename": "main.cpp",
     "content": "#include <iostream>\n"
 }
+CPP_CODE_NO_LANGUAGE_NO_OPTION = {
+    "language": {
+        "name": None,
+        "option": None
+    },
+    "filename": "main.cpp",
+    "content": "#include <iostream>\n"
+}
+UNKNOWN_CODE_NO_LANGUAGE_NO_OPTION = {
+    "language": {
+        "name": None,
+        "option": None
+    },
+    "filename": "main.asdf",
+    "content": "#include <iostream>\n"
+}
+CPP_CODE_NO_LANGUAGE = {
+    "language": {
+        "name": None,
+        "option": "C++17"
+    },
+    "filename": "main.cpp",
+    "content": "#include <iostream>\n"
+}
 RS_13_CODE = {
     "language": {
         "name": "C++",
@@ -133,6 +157,91 @@ fn main() {
     ),
     SubmissionScenario(
         NewSubmission(course_id="cses", task_id=42, submission_json=CPP_CODE),
+        [
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": "C++17"
+                },
+                "status": "PENDING",
+                "pending": True,
+            },
+
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": "C++17"
+                },
+                "status": "READY",
+                "pending": False,
+                "result": "WRONG ANSWER",
+                "compiler": """input/code.cpp: In function 'int main()':
+input/code.cpp:27:29: warning: comparison between signed and unsigned integer \
+expressions [-Wsign-compare]
+for (int i = 0; i < a.size(); i++) {
+""",
+                "tests": [{
+                    "number": 1,
+                    "verdict": "ACCEPTED",
+                    "time": 120
+                }]
+            }
+        ]
+    ),
+    SubmissionScenario(
+        NewSubmission(course_id="cses", task_id=111, submission_json=UNKNOWN_CODE_NO_LANGUAGE_NO_OPTION),
+        [
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": None,
+                    "option": None
+                },
+                "status": "READY",
+                "result": "INVALID LANGUAGE",
+                "pending": False,
+            }
+        ]
+    ),
+    SubmissionScenario(
+        NewSubmission(course_id="cses", task_id=444, submission_json=CPP_CODE_NO_LANGUAGE_NO_OPTION),
+        [
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": "C++17"
+                },
+                "status": "PENDING",
+                "pending": True,
+            },
+
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": "C++17"
+                },
+                "status": "READY",
+                "pending": False,
+                "result": "WRONG ANSWER",
+                "compiler": """input/code.cpp: In function 'int main()':
+input/code.cpp:27:29: warning: comparison between signed and unsigned integer \
+expressions [-Wsign-compare]
+for (int i = 0; i < a.size(); i++) {
+""",
+                "tests": [{
+                    "number": 1,
+                    "verdict": "ACCEPTED",
+                    "time": 120
+                }]
+            }
+        ]
+    ),
+    SubmissionScenario(
+        NewSubmission(course_id="cses", task_id=555, submission_json=CPP_CODE_NO_LANGUAGE),
         [
             {
                 "time": "2017-07-21T17:32:28Z",

--- a/api/mock_server/scenarios.py
+++ b/api/mock_server/scenarios.py
@@ -46,6 +46,8 @@ RS_13_CODE = {
     "content": "use std::io;\n\nfn main() {\n"
 }
 
+DEFAULT_TASK = 34
+
 
 scenarios = [
     SubmissionScenario(
@@ -391,5 +393,35 @@ input/code.cpp:3:11: warning: 'x' is used uninitialized in this function [-Wunin
                     },
                 ]}
         ]
+    ),
+    SubmissionScenario(
+        NewSubmission(course_id="cses", task_id=DEFAULT_TASK, submission_json=CPP_CODE),
+        [
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": "C++17"
+                },
+                "status": "PENDING",
+                "pending": True,
+            },
+
+            {
+                "time": "2017-07-21T17:32:28Z",
+                "language": {
+                    "name": "C++",
+                    "option": None
+                },
+                "status": "READY",
+                "pending": False,
+                "result": "ACCEPTED",
+                "tests": [{
+                    "number": 1,
+                    "verdict": "ACCEPTED",
+                    "time": 120
+                }]
+            }
+        ],
     ),
 ]

--- a/api/mock_server/server_state.py
+++ b/api/mock_server/server_state.py
@@ -55,7 +55,7 @@ class ServerState:
 
         return submission_id
 
-    def get_submission_info(self, course_id, task_id, submission_id):
+    def get_submission_info(self, course_id, submission_id):
         """Returns the next state of the submission `submission_id`"""
         if submission_id not in self.submission_trackers:
             return None

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -371,11 +371,11 @@ paths:
               schema:
                 type: object
                 required:
-                  - id
+                  - submission_id
                   - task_id
                 additionalProperties: false
                 properties:
-                  id:
+                  submission_id:
                     description: ID of the resulting submission.
                     type: integer
                   task_id:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -220,7 +220,7 @@ components:
       schema:
         type: integer
       required: false
-      description: Task ID. If it is not provided the server checks it automatically based on the file name.
+      description: Task ID. If not provided the server tries to deduce it from the file name.
 
     SubmissionId:
       in: path

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -214,15 +214,12 @@ components:
         Alphanumeric identifier of the course. Same as in course URLs.
 
     TaskId:
-      in: path
+      in: query
       name: task_id
       schema:
-        oneOf:
-          - type: integer
-          - type: string
-            enum: [ auto ]
-      required: true
-      description: Task ID. "auto" tells the server to recognize the task automatically.
+        type: integer
+      required: false
+      description: Task ID. If it is not provided the server checks it automatically based on the file name.
 
     SubmissionId:
       in: path
@@ -326,7 +323,7 @@ paths:
 
         "5XX":
           $ref: "#/components/responses/ServerError"
-  /courses/{course_id}/tasks/{task_id}/submissions:
+  /courses/{course_id}/submissions:
     post:
       operationId: app.submissions_post
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -115,6 +115,7 @@ components:
       properties:
         name:
           type: string
+          nullable: true
           description: >
             Name of the language, e.g. "C++", "Haskell", "Python2".
         option:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -215,7 +215,7 @@ components:
 
     TaskId:
       in: query
-      name: task_id
+      name: task
       schema:
         type: integer
       required: false
@@ -323,6 +323,7 @@ paths:
 
         "5XX":
           $ref: "#/components/responses/ServerError"
+
   /courses/{course_id}/submissions:
     post:
       operationId: app.submissions_post
@@ -371,10 +372,14 @@ paths:
                 type: object
                 required:
                   - id
+                  - task_id
                 additionalProperties: false
                 properties:
                   id:
                     description: ID of the resulting submission.
+                    type: integer
+                  task_id:
+                    description: ID of the submitted task.
                     type: integer
         "4XX":
           $ref: "#/components/responses/ClientError"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -217,9 +217,12 @@ components:
       in: path
       name: task_id
       schema:
-        type: integer
+        oneOf:
+          - type: integer
+          - type: string
+            enum: [ auto ]
       required: true
-      description: Task ID.
+      description: Task ID. "auto" tells the server to recognize the task automatically.
 
     SubmissionId:
       in: path
@@ -227,7 +230,7 @@ components:
       schema:
         type: integer
       required: true
-      description: Submission ID.
+      description: Submission ID. 
 
   # define possible authentication methods
   securitySchemes:
@@ -249,7 +252,7 @@ paths:
       summary: Logs in the user with CSES credentials
       description: >
         Logs the user in with CSES credentials. Returns an API token
-        that can be used to authenticate subsequent API queries.
+        that can be used toauthenticate subsequent API queries.
 
       security: []
 
@@ -381,7 +384,7 @@ paths:
         "5XX":
           $ref: "#/components/responses/ServerError"
 
-  /courses/{course_id}/tasks/{task_id}/submissions/{submission_id}:
+  /courses/{course_id}/submissions/{submission_id}:
     get:
       operationId: app.get_submission
 
@@ -392,7 +395,6 @@ paths:
 
       parameters:
         - $ref: "#/components/parameters/CourseId"
-        - $ref: "#/components/parameters/TaskId"
         - $ref: "#/components/parameters/SubmissionId"
         - in: query
           name: poll

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,7 @@
 mod escape;
 use escape::Escape;
 
-use crate::entities::{Language, SubmissionInfo};
+use crate::entities::{Language, SubmissionInfo, SubmissionResponse};
 use crate::service::Login;
 use miniserde::{json, Deserialize, Serialize};
 use minreq::Response;
@@ -53,7 +53,7 @@ pub trait CsesApi {
         course_id: &str,
         task_id: u64,
         submission: &CodeSubmit,
-    ) -> ApiResult<u64>;
+    ) -> ApiResult<SubmissionResponse>;
     fn get_submit(
         &self,
         token: &str,
@@ -89,7 +89,7 @@ impl CsesApi for CsesHttpApi {
         course_id: &str,
         task_id: u64,
         submission: &CodeSubmit,
-    ) -> ApiResult<u64> {
+    ) -> ApiResult<SubmissionResponse> {
         let response = minreq::post(format!(
             "{}/courses/{}/submissions?task={}",
             self.url,
@@ -102,8 +102,7 @@ impl CsesApi for CsesHttpApi {
         .send()?;
         check_error(&response)?;
         let response_body: SubmissionResponse = json::from_str(response.as_str()?)?;
-        let submission_id = response_body.id;
-        Ok(submission_id)
+        Ok(response_body)
     }
 
     fn get_submit(
@@ -157,11 +156,6 @@ struct LoginResponse {
 pub struct ErrorResponse {
     pub message: String,
     pub code: ErrorCode,
-}
-
-#[derive(Deserialize)]
-struct SubmissionResponse {
-    id: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -100,12 +100,10 @@ impl CsesApi for CsesHttpApi {
         .with_header("Content-Type", "application/json");
 
         if let Some(task_id) = task_id {
-            request = request
-                .with_param("task", task_id.to_string());
+            request = request.with_param("task", task_id.to_string());
         }
 
-        let response = request.
-            send()?;
+        let response = request.send()?;
         check_error(&response)?;
         let response_body: SubmissionResponse = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -126,7 +124,8 @@ impl CsesApi for CsesHttpApi {
             submission_id
         ))
         .with_header("X-Auth-Token", token)
-        .with_param("poll", poll).send()?;
+        .with_param("poll", poll)
+        .send()?;
         check_error(&response)?;
         let response_body: SubmissionInfo = json::from_str(response.as_str()?)?;
         Ok(response_body)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -58,7 +58,6 @@ pub trait CsesApi {
         &self,
         token: &str,
         course_id: &str,
-        task_id: u64,
         submission_id: u64,
         poll: bool,
     ) -> ApiResult<SubmissionInfo>;
@@ -92,7 +91,7 @@ impl CsesApi for CsesHttpApi {
         submission: &CodeSubmit,
     ) -> ApiResult<u64> {
         let response = minreq::post(format!(
-            "{}/courses/{}/tasks/{}/submissions",
+            "{}/courses/{}/submissions?task={}",
             self.url,
             Escape(course_id),
             task_id
@@ -111,16 +110,14 @@ impl CsesApi for CsesHttpApi {
         &self,
         token: &str,
         course_id: &str,
-        task_id: u64,
         submission_id: u64,
         poll: bool,
     ) -> ApiResult<SubmissionInfo> {
         let poll = if poll { "true" } else { "false" };
         let response = minreq::get(format!(
-            "{}/courses/{}/tasks/{}/submissions/{}?poll={}",
+            "{}/courses/{}/submissions/{}?poll={}",
             self.url,
             Escape(course_id),
-            task_id,
             submission_id,
             poll
         ))

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 
+use crate::entities::Language;
+
 pub static HELP_STR: &str = r#"CSES CLI
 
 USAGE:
@@ -46,8 +48,7 @@ pub enum Command {
 pub struct Submit {
     pub course_id: Option<String>,
     pub task_id: Option<u64>,
-    pub language_name: Option<String>,
-    pub language_option: Option<String>,
+    pub language: Language,
     pub file_name: String,
 }
 impl Submit {
@@ -55,8 +56,10 @@ impl Submit {
         Ok(Submit {
             course_id: pargs.opt_value_from_str(["-c", "--course"])?,
             task_id: pargs.opt_value_from_str(["-t", "--task"])?,
-            language_name: pargs.opt_value_from_str(["-l", "--language"])?,
-            language_option: pargs.opt_value_from_str(["-o", "--lang-opt"])?,
+            language: Language {
+                name: pargs.opt_value_from_str(["-l", "--language"])?,
+                option: pargs.opt_value_from_str(["-o", "--lang-opt"])?,
+            },
             file_name: {
                 if let Ok(file_name) = pargs.free_from_str() {
                     file_name
@@ -249,7 +252,7 @@ mod tests {
 
         assert!(matches!(
             command,
-            Command::Submit(Submit { language_name: Some(lang), .. })
+            Command::Submit(Submit { language: Language { name: Some(lang), ..}, .. })
             if lang == "Rust"
         ));
     }
@@ -261,7 +264,7 @@ mod tests {
 
         assert!(matches!(
             command,
-            Command::Submit(Submit { language_name: Some(lang), .. })
+            Command::Submit(Submit { language: Language { name: Some(lang), .. }, .. })
             if lang == "Rust"
         ));
     }
@@ -273,7 +276,7 @@ mod tests {
 
         assert!(matches!(
             command,
-            Command::Submit(Submit { language_option: Some(opt), .. })
+            Command::Submit(Submit { language: Language{ option: Some(opt), .. }, .. })
             if opt == "C++17"
         ));
     }
@@ -284,7 +287,7 @@ mod tests {
 
         assert!(matches!(
             command,
-            Command::Submit(Submit { language_option: Some(opt), .. })
+            Command::Submit(Submit { language: Language{ option: Some(opt), .. }, ..})
             if opt == "C++17"
         ));
     }

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -20,7 +20,7 @@ pub struct SubmissionInfo {
 
 #[derive(Deserialize)]
 pub struct SubmissionResponse {
-    pub id: u64,
+    pub submission_id: u64,
     pub task_id: u64,
 }
 

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -18,6 +18,12 @@ pub struct SubmissionInfo {
     pub compiler: Option<String>,
 }
 
+#[derive(Deserialize)]
+pub struct SubmissionResponse {
+    pub id: u64,
+    pub task_id: u64,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SubmissionTestInfo {
     pub number: u64,

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,8 +1,8 @@
 use miniserde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Language {
-    pub name: String,
+    pub name: Option<String>,
     pub option: Option<String>,
 }
 
@@ -35,4 +35,12 @@ pub struct SubmissionTestInfo {
 pub struct TestProgress {
     pub finished_tests: u64,
     pub total_tests: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SubmitParameters {
+    pub course: String,
+    pub file: String,
+    pub task: Option<u64>,
+    pub language: Language,
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -2,7 +2,7 @@ mod login;
 pub use login::{login, login_exists, logout, Login};
 
 pub(crate) mod submit;
-pub use submit::{submission_info, submit, update_submit_parameters};
+pub use submit::{submission_info, submit, create_submit_parameters};
 
 use crate::{Resources, Storage, RP};
 use anyhow::{anyhow, Result};

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -2,7 +2,7 @@ mod login;
 pub use login::{login, login_exists, logout, Login};
 
 pub(crate) mod submit;
-pub use submit::{submission_info, submit, create_submit_parameters};
+pub use submit::{create_submit_parameters, submission_info, submit};
 
 use crate::{Resources, Storage, RP};
 use anyhow::{anyhow, Result};

--- a/src/service/submit.rs
+++ b/src/service/submit.rs
@@ -72,10 +72,9 @@ pub fn submission_info(
     (|| -> Result<_> {
         let storage = res.storage.get();
         let course_id = storage.get_course().unwrap();
-        let task_id = storage.get_task().unwrap();
         Ok(res
             .api
-            .get_submit(require_login(res)?, course_id, task_id, submission_id, poll)?)
+            .get_submit(require_login(res)?, course_id, submission_id, poll)?)
     })()
     .context("Failed querying submission status from the server")
 }

--- a/src/service/submit.rs
+++ b/src/service/submit.rs
@@ -1,5 +1,6 @@
 use super::require_login;
 use crate::command;
+use crate::entities::SubmissionResponse;
 use crate::{
     api::CodeSubmit,
     entities::{Language, SubmissionInfo},
@@ -28,7 +29,7 @@ pub fn update_submit_parameters(
     Ok(())
 }
 
-pub fn submit(res: &mut Resources<impl RP>, path: String) -> Result<u64> {
+pub fn submit(res: &mut Resources<impl RP>, path: String) -> Result<SubmissionResponse> {
     (|| -> Result<_> {
         require_login(res)?;
         let storage = res.storage.get();

--- a/src/service/submit.rs
+++ b/src/service/submit.rs
@@ -2,10 +2,7 @@ use super::require_login;
 use crate::command;
 use crate::entities::SubmissionResponse;
 use crate::entities::SubmitParameters;
-use crate::{
-    api::CodeSubmit,
-    entities::SubmissionInfo,
-};
+use crate::{api::CodeSubmit, entities::SubmissionInfo};
 use crate::{CsesApi, Filesystem, Resources, Storage, RP};
 use anyhow::{anyhow, Context, Result};
 
@@ -20,7 +17,8 @@ pub fn create_submit_parameters(
     res.storage.save()?;
     let storage = res.storage.get();
     Ok(SubmitParameters {
-        course: storage.get_course()
+        course: storage
+            .get_course()
             .ok_or_else(|| anyhow!("Course not provided"))?
             .to_owned(),
         file: parameters.file_name.clone(),
@@ -29,7 +27,10 @@ pub fn create_submit_parameters(
     })
 }
 
-pub fn submit(res: &mut Resources<impl RP>, submit_parameters: SubmitParameters) -> Result<SubmissionResponse> {
+pub fn submit(
+    res: &mut Resources<impl RP>,
+    submit_parameters: SubmitParameters,
+) -> Result<SubmissionResponse> {
     (|| -> Result<_> {
         require_login(res)?;
         let course_id = submit_parameters.course;

--- a/src/service/submit.rs
+++ b/src/service/submit.rs
@@ -1,60 +1,44 @@
 use super::require_login;
 use crate::command;
 use crate::entities::SubmissionResponse;
+use crate::entities::SubmitParameters;
 use crate::{
     api::CodeSubmit,
-    entities::{Language, SubmissionInfo},
+    entities::SubmissionInfo,
 };
 use crate::{CsesApi, Filesystem, Resources, Storage, RP};
 use anyhow::{anyhow, Context, Result};
 
-pub fn update_submit_parameters(
+pub fn create_submit_parameters(
     res: &mut Resources<impl RP>,
     parameters: &command::Submit,
-) -> Result<()> {
+) -> Result<SubmitParameters> {
     let storage = res.storage.get_mut();
     if let Some(ref course_id) = parameters.course_id {
         storage.set_course(course_id.clone());
     }
-    if let Some(task_id) = parameters.task_id {
-        storage.set_task(task_id);
-    }
-    if let Some(ref language_name) = parameters.language_name {
-        storage.set_language(language_name.clone());
-    }
-    if let Some(ref language_option) = parameters.language_option {
-        storage.set_option(language_option.clone());
-    }
     res.storage.save()?;
-    Ok(())
+    let storage = res.storage.get();
+    Ok(SubmitParameters {
+        course: storage.get_course()
+            .ok_or_else(|| anyhow!("Course not provided"))?
+            .to_owned(),
+        file: parameters.file_name.clone(),
+        task: parameters.task_id,
+        language: parameters.language.clone(),
+    })
 }
 
-pub fn submit(res: &mut Resources<impl RP>, path: String) -> Result<SubmissionResponse> {
+pub fn submit(res: &mut Resources<impl RP>, submit_parameters: SubmitParameters) -> Result<SubmissionResponse> {
     (|| -> Result<_> {
         require_login(res)?;
-        let storage = res.storage.get();
-        let course_id = storage
-            .get_course()
-            .ok_or_else(|| anyhow!("Course not provided"))?
-            .to_owned();
-        let task_id = storage
-            .get_task()
-            .ok_or_else(|| anyhow!("Task not provided"))?
-            .to_owned();
-        let language_name = storage
-            .get_language()
-            .ok_or_else(|| anyhow!("Language not provided"))?
-            .to_owned();
-        let language_option = storage.get_option().map(|t| t.to_owned());
-
-        let content = res.filesystem.get_file(&path)?;
-        let filename = res.filesystem.get_file_name(&path)?;
+        let course_id = submit_parameters.course;
+        let task_id = submit_parameters.task;
+        let content = res.filesystem.get_file(&submit_parameters.file)?;
+        let filename = res.filesystem.get_file_name(&submit_parameters.file)?;
         let content = res.filesystem.encode_base64(&content);
         let submission = CodeSubmit {
-            language: Language {
-                name: language_name,
-                option: language_option,
-            },
+            language: submit_parameters.language,
             filename,
             content,
         };

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,10 +8,6 @@ use std::path::PathBuf;
 pub struct StorageData {
     token: Option<String>,
     course: Option<String>,
-    task: Option<u64>,
-    language: Option<String>,
-    option: Option<String>,
-    file: Option<String>,
 }
 
 #[cfg(unix)]
@@ -35,35 +31,11 @@ impl StorageData {
     pub fn get_course(&self) -> Option<&str> {
         self.course.as_deref()
     }
-    pub fn get_task(&self) -> Option<u64> {
-        self.task
-    }
-    pub fn get_language(&self) -> Option<&str> {
-        self.language.as_deref()
-    }
-    pub fn get_option(&self) -> Option<&str> {
-        self.option.as_deref()
-    }
-    pub fn get_file(&self) -> Option<&str> {
-        self.file.as_deref()
-    }
     pub fn set_token(&mut self, val: String) {
         self.token = Some(val);
     }
     pub fn set_course(&mut self, val: String) {
         self.course = Some(val);
-    }
-    pub fn set_task(&mut self, val: u64) {
-        self.task = Some(val);
-    }
-    pub fn set_language(&mut self, val: String) {
-        self.language = Some(val);
-    }
-    pub fn set_option(&mut self, val: String) {
-        self.option = Some(val);
-    }
-    pub fn set_file(&mut self, val: String) {
-        self.file = Some(val);
     }
 }
 
@@ -133,18 +105,7 @@ mod tests {
         let mut storage_data: StorageData = Default::default();
         storage_data.set_token(String::from("token"));
         storage_data.set_course(String::from("course"));
-        storage_data.set_task(42);
-        storage_data.set_language(String::from("language"));
-        storage_data.set_option(String::from("option"));
-        storage_data.set_file(String::from("file"));
         assert_eq!(String::from("token"), storage_data.get_token().unwrap());
         assert_eq!(String::from("course"), storage_data.get_course().unwrap());
-        assert_eq!(42, storage_data.get_task().unwrap());
-        assert_eq!(
-            String::from("language"),
-            storage_data.get_language().unwrap()
-        );
-        assert_eq!(String::from("option"), storage_data.get_option().unwrap());
-        assert_eq!(String::from("file"), storage_data.get_file().unwrap());
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,7 @@
 mod submit;
 
 use crate::api::CodeSubmit;
+use crate::entities::SubmissionResponse;
 use crate::storage::StorageData;
 use crate::{api::ApiResult, api::MockCsesApi, service::Login};
 use crate::{CsesApi, Filesystem, Resources, Storage};
@@ -23,7 +24,7 @@ impl CsesApi for FakeCsesApi {
         _course_id: &str,
         _task_id: u64,
         _submission: &CodeSubmit,
-    ) -> ApiResult<u64> {
+    ) -> ApiResult<SubmissionResponse> {
         todo!()
     }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -22,7 +22,7 @@ impl CsesApi for FakeCsesApi {
         &self,
         _token: &str,
         _course_id: &str,
-        _task_id: u64,
+        _task_id: Option<u64>,
         _submission: &CodeSubmit,
     ) -> ApiResult<SubmissionResponse> {
         todo!()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -31,7 +31,6 @@ impl CsesApi for FakeCsesApi {
         &self,
         _token: &str,
         _course_id: &str,
-        _task_id: u64,
         _submission_id: u64,
         _poll: bool,
     ) -> ApiResult<crate::entities::SubmissionInfo> {

--- a/src/test/submit.rs
+++ b/src/test/submit.rs
@@ -50,5 +50,6 @@ fn submit_mock() -> Result<()> {
     fake_resources.storage.data = storage_data;
     let submission_response = service::submit(&mut fake_resources, "test".to_string())?;
     assert_eq!(submission_response.submission_id, 17);
+    assert_eq!(submission_response.task_id, 4);
     Ok(())
 }

--- a/src/test/submit.rs
+++ b/src/test/submit.rs
@@ -54,7 +54,10 @@ fn submit_mock() -> Result<()> {
         course: "17".to_owned(),
         file: "extracted_filename".to_owned(),
         task: Some(3),
-        language: Language { name: Some("Python".to_owned()), option: None },
+        language: Language {
+            name: Some("Python".to_owned()),
+            option: None,
+        },
     };
     let submission_response = service::submit(&mut fake_resources, submit_params)?;
     assert_eq!(submission_response.submission_id, 17);

--- a/src/test/submit.rs
+++ b/src/test/submit.rs
@@ -41,7 +41,7 @@ fn submit_mock() -> Result<()> {
                 && submission.filename == "extracted_filename"
                 && submission.content == "testing"
         })
-        .returning(|_, _, _, _| Ok(SubmissionResponse { id: 17, task_id: 4 }));
+        .returning(|_, _, _, _| Ok(SubmissionResponse { submission_id: 17, task_id: 4 }));
     let mut storage_data: StorageData = Default::default();
     storage_data.set_token("gnewwoiJ".to_string());
     storage_data.set_language("Python".to_string());
@@ -49,6 +49,6 @@ fn submit_mock() -> Result<()> {
     storage_data.set_task(3);
     fake_resources.storage.data = storage_data;
     let submission_response = service::submit(&mut fake_resources, "test".to_string())?;
-    assert_eq!(submission_response.id, 17);
+    assert_eq!(submission_response.submission_id, 17);
     Ok(())
 }

--- a/src/test/submit.rs
+++ b/src/test/submit.rs
@@ -1,6 +1,7 @@
 use super::fake_resources;
 use super::fake_resources_with_mock_api;
 use crate::command::Submit;
+use crate::entities::SubmissionResponse;
 use crate::service;
 use crate::storage::{Storage, StorageData};
 use anyhow::Result;
@@ -40,14 +41,14 @@ fn submit_mock() -> Result<()> {
                 && submission.filename == "extracted_filename"
                 && submission.content == "testing"
         })
-        .returning(|_, _, _, _| Ok(17));
+        .returning(|_, _, _, _| Ok(SubmissionResponse { id: 17, task_id: 4 }));
     let mut storage_data: StorageData = Default::default();
     storage_data.set_token("gnewwoiJ".to_string());
     storage_data.set_language("Python".to_string());
     storage_data.set_course("17".to_string());
     storage_data.set_task(3);
     fake_resources.storage.data = storage_data;
-    let submission_id = service::submit(&mut fake_resources, "test".to_string())?;
-    assert_eq!(submission_id, 17);
+    let submission_response = service::submit(&mut fake_resources, "test".to_string())?;
+    assert_eq!(submission_response.id, 17);
     Ok(())
 }

--- a/src/test/submit.rs
+++ b/src/test/submit.rs
@@ -41,7 +41,12 @@ fn submit_mock() -> Result<()> {
                 && submission.filename == "extracted_filename"
                 && submission.content == "testing"
         })
-        .returning(|_, _, _, _| Ok(SubmissionResponse { submission_id: 17, task_id: 4 }));
+        .returning(|_, _, _, _| {
+            Ok(SubmissionResponse {
+                submission_id: 17,
+                task_id: 4,
+            })
+        });
     let mut storage_data: StorageData = Default::default();
     storage_data.set_token("gnewwoiJ".to_string());
     storage_data.set_language("Python".to_string());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,7 +39,7 @@ impl<R: ResourcesProvider> Ui<R> {
             }
             Command::Submit(submit) => {
                 let submission_response = submit::submit(self, submit)?;
-                submission::print_submission_info(self, submission_response.id, true)?;
+                submission::print_submission_info(self, submission_response.submission_id, true)?;
             }
             _ => {
                 self.term.write_line("Command not yet implemented")?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -38,8 +38,8 @@ impl<R: ResourcesProvider> Ui<R> {
                 login::logout(self)?;
             }
             Command::Submit(submit) => {
-                let submission_id = submit::submit(self, submit)?;
-                submission::print_submission_info(self, submission_id, true)?;
+                let submission_response = submit::submit(self, submit)?;
+                submission::print_submission_info(self, submission_response.id, true)?;
             }
             _ => {
                 self.term.write_line("Command not yet implemented")?;

--- a/src/ui/submission.rs
+++ b/src/ui/submission.rs
@@ -33,7 +33,11 @@ pub fn print_submission_info(
 fn print_info_header(ui: &mut Ui<impl RP>, submission_info: &SubmissionInfo) -> Result<()> {
     ui.term.write_line("Submission details\n")?;
     writeln!(ui.term, "Submission time: {}", submission_info.time)?;
-    write!(ui.term, "Language: {}", submission_info.language.name)?;
+    write!(
+        ui.term,
+        "Language: {}",
+        submission_info.language.name.as_deref().unwrap_or("?")
+    )?;
     if let Some(ref option) = submission_info.language.option {
         write!(ui.term, " ({})", option)?;
     };

--- a/src/ui/submit.rs
+++ b/src/ui/submit.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use super::Ui;
 
 pub fn submit(ui: &mut Ui<impl RP>, params: command::Submit) -> Result<SubmissionResponse> {
-    service::update_submit_parameters(&mut ui.res, &params)?;
-    let submission_response = service::submit(&mut ui.res, params.file_name)?;
+    let submit_params = service::create_submit_parameters(&mut ui.res, &params)?;
+    let submission_response = service::submit(&mut ui.res, submit_params)?;
     Ok(submission_response)
 }

--- a/src/ui/submit.rs
+++ b/src/ui/submit.rs
@@ -1,10 +1,10 @@
-use crate::{command, service, RP};
+use crate::{command, entities::SubmissionResponse, service, RP};
 use anyhow::Result;
 
 use super::Ui;
 
-pub fn submit(ui: &mut Ui<impl RP>, params: command::Submit) -> Result<u64> {
+pub fn submit(ui: &mut Ui<impl RP>, params: command::Submit) -> Result<SubmissionResponse> {
     service::update_submit_parameters(&mut ui.res, &params)?;
-    let submission_id = service::submit(&mut ui.res, params.file_name)?;
-    Ok(submission_id)
+    let submission_response = service::submit(&mut ui.res, params.file_name)?;
+    Ok(submission_response)
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,4 @@
-use predicates::str::RegexPredicate;
+use predicates::str::{ContainsPredicate, RegexPredicate};
 use std::path::Path;
 
 pub use assert_cmd::prelude::*;
@@ -17,6 +17,10 @@ pub fn command() -> Command {
 
 pub fn regex_match(expr: &str) -> RegexPredicate {
     predicate::str::is_match(expr).unwrap()
+}
+
+pub fn contains(expr: &str) -> ContainsPredicate {
+    predicate::str::contains(expr)
 }
 
 pub fn log_in(user: &str) {

--- a/tests/integration/submit.rs
+++ b/tests/integration/submit.rs
@@ -283,6 +283,8 @@ fn submission_works_without_task() {
         .success()
         .stdout(contains(r"Result: ACCEPTED"))
         .stdout(contains(r"Language: C++ (C++17)"));
+}
+#[distributed_slice(TESTS)]
 fn test_report_is_displayed_with_content() {
     log_in("Olaf");
     create_file("lucky.py", LUCKY_PY_CONTENT);

--- a/tests/integration/submit.rs
+++ b/tests/integration/submit.rs
@@ -269,3 +269,17 @@ fn test_server_returns_null_language() {
         .stdout(contains(r"Result: INVALID LANGUAGE"))
         .stdout(contains(r"Language: ?"));
 }
+#[distributed_slice(TESTS)]
+fn submission_works_without_task() {
+    log_in("uolevi");
+
+    create_file("main.cpp", MAIN_CPP_CONTENT);
+    command()
+        .args(&[
+            "submit", "-c", "cses", "-l", "C++", "-o", "C++17", "main.cpp",
+        ])
+        .assert()
+        .success()
+        .stdout(contains(r"Result: ACCEPTED"))
+        .stdout(contains(r"Language: C++ (C++17)"));
+}

--- a/tests/integration/submit.rs
+++ b/tests/integration/submit.rs
@@ -100,7 +100,7 @@ fn shows_each_test_result() {
 }
 
 #[distributed_slice(TESTS)]
-fn remembers_course_and_language() {
+fn remembers_course() {
     log_in("uolevi");
 
     create_file("13.rs", RS_13_CONTENT);
@@ -113,10 +113,41 @@ fn remembers_course_and_language() {
 
     create_file("main.cpp", MAIN_CPP_CONTENT);
     command()
-        .args(&["submit", "-t", "42", "main.cpp"])
+        .args(&["submit", "-t", "42", "-l", "C++", "-o", "C++17", "main.cpp"])
         .assert()
         .success()
         .stdout(regex_match(r"(?i)status.*ready"));
+}
+#[distributed_slice(TESTS)]
+fn does_not_remember_language_or_option() {
+    log_in("uolevi");
+
+    create_file("13.rs", RS_13_CONTENT);
+    command()
+        .args(&[
+            "submit", "-c", "cses", "-t", "13", "-l", "C++", "-o", "C++17", "13.rs",
+        ])
+        .assert()
+        .success();
+
+    command()
+        .args(&["submit", "-c", "cses", "-t", "13", "-o", "C++17", "13.rs"])
+        .assert()
+        .failure()
+        .stdout(contains(r"Failed submitting file"));
+
+    command()
+        .args(&[
+            "submit", "-c", "cses", "-t", "13", "-l", "C++", "-o", "C++17", "13.rs",
+        ])
+        .assert()
+        .success();
+
+    command()
+        .args(&["submit", "-c", "cses", "-t", "13", "-l", "C++", "13.rs"])
+        .assert()
+        .failure()
+        .stdout(contains(r"Failed submitting file"));
 }
 
 #[distributed_slice(TESTS)]
@@ -131,7 +162,7 @@ fn compiler_report_is_dispayed_with_compile_error() {
         .assert();
     assert
         .success()
-        .stdout(regex_match(r"COMPILE ERROR"))
+        .stdout(contains(r"COMPILE ERROR"))
         .stdout(regex_match(r"(?i)compiler"))
         .stderr(predicate::str::is_empty());
 }
@@ -164,7 +195,7 @@ fn compiler_report_is_dispayed_with_compiler_warnings() {
         .assert();
     assert
         .success()
-        .stdout(regex_match(r"READY"))
+        .stdout(contains(r"READY"))
         .stdout(regex_match(r"(?i)compiler"))
         .stderr(predicate::str::is_empty());
 }
@@ -180,7 +211,61 @@ fn null_test_time_finishes_and_is_printed_correctly() {
         .assert();
     assert
         .success()
-        .stdout(regex_match(r"--"))
-        .stdout(regex_match(r"Result"))
+        .stdout(contains(r"--"))
+        .stdout(contains(r"Result"))
         .stderr(predicate::str::is_empty());
+}
+#[distributed_slice(TESTS)]
+fn null_test_time_finishes_and_is_print() {
+    log_in("kalle");
+    create_file("main.cpp", MAIN_CPP_CONTENT);
+
+    let assert = command()
+        .args(&[
+            "submit", "main.cpp", "-c", "progress", "-t", "7", "-l", "C++", "-o", "C++17",
+        ])
+        .assert();
+    assert
+        .success()
+        .stdout(contains(r"--"))
+        .stdout(contains(r"Result"))
+        .stderr(predicate::str::is_empty());
+}
+#[distributed_slice(TESTS)]
+fn submission_works_without_language_and_option() {
+    log_in("uolevi");
+
+    create_file("main.cpp", MAIN_CPP_CONTENT);
+    command()
+        .args(&["submit", "-c", "cses", "-t", "444", "main.cpp"])
+        .assert()
+        .success()
+        .stdout(contains(r"Result: WRONG ANSWER"))
+        .stdout(contains(r"Language: C++ (C++17)"));
+}
+#[distributed_slice(TESTS)]
+fn submission_works_without_language_with_option() {
+    log_in("uolevi");
+
+    create_file("main.cpp", MAIN_CPP_CONTENT);
+    command()
+        .args(&[
+            "submit", "-c", "cses", "-t", "555", "-o", "C++17", "main.cpp",
+        ])
+        .assert()
+        .success()
+        .stdout(contains(r"Result: WRONG ANSWER"))
+        .stdout(contains(r"Language: C++ (C++17)"));
+}
+#[distributed_slice(TESTS)]
+fn test_server_returns_null_language() {
+    log_in("uolevi");
+
+    create_file("main.asdf", MAIN_CPP_CONTENT);
+    command()
+        .args(&["submit", "-c", "cses", "-t", "111", "main.asdf"])
+        .assert()
+        .success()
+        .stdout(contains(r"Result: INVALID LANGUAGE"))
+        .stdout(contains(r"Language: ?"));
 }


### PR DESCRIPTION
Tasks can now be submitted without specifying what task is being submitted. Tasks will be recognized by the server based on the submitted file's name. The server now also returns the task's id in the response.