### PR TITLE
Update minreq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "assert_cmd"
@@ -246,9 +246,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
 
 [[package]]
 name = "linkme"
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44995f40971293bc7515239a49e2f7e24c87581a12a9bba8ded89d769d069c67"
+checksum = "d5f7db7a675c4b46b8842105b9371d6151e95fbbecd9b0e54dc2ea814397d2cc"
 dependencies = [
  "log",
  "native-tls",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 pico-args = "0.4"
 console = "0.14"
 miniserde = "0.1"
-minreq = { version = "=2.4.0", features = ["https-native"] }
+minreq = { version = "2.4.2", features = ["https-native"] }
 anyhow = "1"
 thiserror = "1"
 base64 = "0.13.0"

--- a/tests/integration/login.rs
+++ b/tests/integration/login.rs
@@ -52,6 +52,15 @@ fn user_can_overwrite_current_login() {
         .stderr(predicate::str::is_empty());
 }
 
+#[distributed_slice(TESTS)]
+fn test_login_returns_correct_link() {
+    command()
+        .args(&["login"])
+        .assert()
+        .success()
+        .stdout(contains("http://127.0.0.1:4011/authorize-login?token="));
+}
+
 fn successful_login_attempt() -> Assert {
     command().args(&["login"]).assert()
 }


### PR DESCRIPTION
    Minreq 2.4.1 left out port from generated url.
    (see https://github.com/neonmoe/minreq/issues/61).

    Update to a newer version of minreq to fix this.