### PR TITLE
No command provided hint changes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -40,9 +40,6 @@ OPTIONS:
         Selects the template with filename "file".
 "#;
 
-pub static NO_COMMAND_PROVIDED_HINT: &str = r#"No command provided. Run "help" 
-to get a list of available commands."#;
-
 pub static LANGUAGE_HINT: &str = r#"You can manually specify the language with
 the "-l" or "--language" flags, e.g.:
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Error, Result};
 use console::{Style, Term};
 
 use crate::api::ApiError;
-use crate::command::{HELP_STR, LANGUAGE_HINT, NO_COMMAND_PROVIDED_HINT, TASK_HINT};
+use crate::command::{HELP_STR, LANGUAGE_HINT, TASK_HINT};
 use crate::service;
 use crate::{Command, Resources, ResourcesProvider, RP};
 
@@ -36,7 +36,8 @@ impl<R: ResourcesProvider> Ui<R> {
         service::ping(&mut self.res);
         match command {
             Command::None => {
-                self.term.write_line(NO_COMMAND_PROVIDED_HINT)?;
+                self.term.write_line(HELP_STR)?;
+                login::status(self).context("Could not get login status")?;
             }
             Command::Help => {
                 self.term.write_str(HELP_STR)?;

--- a/tests/integration/help.rs
+++ b/tests/integration/help.rs
@@ -50,6 +50,7 @@ fn hint_is_displayed_if_no_command_is_provided() {
     let assert = command().assert();
     assert
         .success()
-        .stdout(regex_match(r"(?i)run.*help"))
+        .stdout(regex_match(r"(?i)usage"))
+        .stdout(regex_match(r"(?i)login status"))
         .stderr(predicate::str::is_empty());
 }


### PR DESCRIPTION
The help and status command outputs are printed if no command is provided.