### PR TITLE
Support API debugging

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -14,17 +14,12 @@ use trace_send::TraceSend;
 
 pub struct CsesHttpApi {
     url: String,
+    trace: bool,
 }
 
 impl CsesHttpApi {
-    pub fn new(url: String) -> Self {
-        Self { url }
-    }
-}
-
-impl Default for CsesHttpApi {
-    fn default() -> Self {
-        Self::new(String::from("http://127.0.0.1:4010"))
+    pub fn new(url: String, trace: bool) -> Self {
+        Self { url, trace }
     }
 }
 
@@ -94,7 +89,7 @@ pub trait CsesApi {
 
 impl CsesApi for CsesHttpApi {
     fn login(&self) -> ApiResult<LoginResponse> {
-        let response = minreq::post(format!("{}/login", self.url)).trace_send()?;
+        let response = minreq::post(format!("{}/login", self.url)).trace_send(self.trace)?;
         check_error(&response)?;
         Ok(json::from_str(response.as_str()?)?)
     }
@@ -102,7 +97,7 @@ impl CsesApi for CsesHttpApi {
     fn login_status(&self, token: &str) -> ApiResult<UserOutline> {
         let response = minreq::get(format!("{}/login", self.url))
             .with_header("X-Auth-Token", token)
-            .trace_send()?;
+            .trace_send(self.trace)?;
         check_error(&response)?;
         let response: UserOutline = json::from_str(response.as_str()?)?;
         Ok(response)
@@ -111,7 +106,7 @@ impl CsesApi for CsesHttpApi {
     fn logout(&self, token: &str) -> ApiResult<()> {
         let response = minreq::post(format!("{}/logout", self.url))
             .with_header("X-Auth-Token", token)
-            .trace_send()?;
+            .trace_send(self.trace)?;
         check_error(&response)?;
         Ok(())
     }
@@ -136,7 +131,7 @@ impl CsesApi for CsesHttpApi {
             request = request.with_param("task", task_id.to_string());
         }
 
-        let response = request.trace_send()?;
+        let response = request.trace_send(self.trace)?;
         check_error(&response)?;
         let response_body: SubmissionInfo = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -158,7 +153,7 @@ impl CsesApi for CsesHttpApi {
         ))
         .with_header("X-Auth-Token", token)
         .with_param("poll", poll)
-        .trace_send()?;
+        .trace_send(self.trace)?;
         check_error(&response)?;
         let response_body: SubmissionInfo = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -177,7 +172,7 @@ impl CsesApi for CsesHttpApi {
         ))
         .with_header("X-Auth-Token", token)
         .with_param("task", task_id.to_string())
-        .trace_send()?;
+        .trace_send(self.trace)?;
         check_error(&response)?;
         let response_body: SubmissionList = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -188,13 +183,14 @@ impl CsesApi for CsesHttpApi {
             Some(token) => {
                 let response = minreq::get(format!("{}/courses", self.url))
                     .with_header("X-Auth-Token", token)
-                    .trace_send()?;
+                    .trace_send(self.trace)?;
                 check_error(&response)?;
                 let course_list: CourseList = json::from_str(response.as_str()?)?;
                 Ok(course_list)
             }
             None => {
-                let response = minreq::get(format!("{}/courses", self.url)).trace_send()?;
+                let response =
+                    minreq::get(format!("{}/courses", self.url)).trace_send(self.trace)?;
                 check_error(&response)?;
                 let course_list: CourseList = json::from_str(response.as_str()?)?;
                 Ok(course_list)
@@ -211,7 +207,7 @@ impl CsesApi for CsesHttpApi {
         if let Some(token) = token {
             request = request.with_header("X-Auth-Token", token);
         }
-        let response = request.trace_send()?;
+        let response = request.trace_send(self.trace)?;
         check_error(&response)?;
         let course_content: CourseContent = json::from_str(response.as_str()?)?;
         Ok(course_content)
@@ -242,7 +238,7 @@ impl CsesApi for CsesHttpApi {
         if let Some(file_name) = file_name {
             request = request.with_param("filename", file_name);
         }
-        let response = request.trace_send()?;
+        let response = request.trace_send(self.trace)?;
         check_error(&response)?;
         Ok(json::from_str(response.as_str()?)?)
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 mod escape;
+mod trace_send;
 use crate::entities::{
     CourseContent, CourseList, Language, SubmissionInfo, SubmissionList, TemplateResponse,
     UserOutline,
@@ -9,6 +10,7 @@ use minreq::Response;
 #[cfg(test)]
 use mockall::automock;
 use thiserror::Error;
+use trace_send::TraceSend;
 
 pub struct CsesHttpApi {
     url: String,
@@ -92,7 +94,7 @@ pub trait CsesApi {
 
 impl CsesApi for CsesHttpApi {
     fn login(&self) -> ApiResult<LoginResponse> {
-        let response = minreq::post(format!("{}/login", self.url)).send()?;
+        let response = minreq::post(format!("{}/login", self.url)).trace_send()?;
         check_error(&response)?;
         Ok(json::from_str(response.as_str()?)?)
     }
@@ -100,7 +102,7 @@ impl CsesApi for CsesHttpApi {
     fn login_status(&self, token: &str) -> ApiResult<UserOutline> {
         let response = minreq::get(format!("{}/login", self.url))
             .with_header("X-Auth-Token", token)
-            .send()?;
+            .trace_send()?;
         check_error(&response)?;
         let response: UserOutline = json::from_str(response.as_str()?)?;
         Ok(response)
@@ -109,7 +111,7 @@ impl CsesApi for CsesHttpApi {
     fn logout(&self, token: &str) -> ApiResult<()> {
         let response = minreq::post(format!("{}/logout", self.url))
             .with_header("X-Auth-Token", token)
-            .send()?;
+            .trace_send()?;
         check_error(&response)?;
         Ok(())
     }
@@ -134,7 +136,7 @@ impl CsesApi for CsesHttpApi {
             request = request.with_param("task", task_id.to_string());
         }
 
-        let response = request.send()?;
+        let response = request.trace_send()?;
         check_error(&response)?;
         let response_body: SubmissionInfo = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -156,7 +158,7 @@ impl CsesApi for CsesHttpApi {
         ))
         .with_header("X-Auth-Token", token)
         .with_param("poll", poll)
-        .send()?;
+        .trace_send()?;
         check_error(&response)?;
         let response_body: SubmissionInfo = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -175,7 +177,7 @@ impl CsesApi for CsesHttpApi {
         ))
         .with_header("X-Auth-Token", token)
         .with_param("task", task_id.to_string())
-        .send()?;
+        .trace_send()?;
         check_error(&response)?;
         let response_body: SubmissionList = json::from_str(response.as_str()?)?;
         Ok(response_body)
@@ -186,13 +188,13 @@ impl CsesApi for CsesHttpApi {
             Some(token) => {
                 let response = minreq::get(format!("{}/courses", self.url))
                     .with_header("X-Auth-Token", token)
-                    .send()?;
+                    .trace_send()?;
                 check_error(&response)?;
                 let course_list: CourseList = json::from_str(response.as_str()?)?;
                 Ok(course_list)
             }
             None => {
-                let response = minreq::get(format!("{}/courses", self.url)).send()?;
+                let response = minreq::get(format!("{}/courses", self.url)).trace_send()?;
                 check_error(&response)?;
                 let course_list: CourseList = json::from_str(response.as_str()?)?;
                 Ok(course_list)
@@ -209,7 +211,7 @@ impl CsesApi for CsesHttpApi {
         if let Some(token) = token {
             request = request.with_header("X-Auth-Token", token);
         }
-        let response = request.send()?;
+        let response = request.trace_send()?;
         check_error(&response)?;
         let course_content: CourseContent = json::from_str(response.as_str()?)?;
         Ok(course_content)
@@ -240,7 +242,7 @@ impl CsesApi for CsesHttpApi {
         if let Some(file_name) = file_name {
             request = request.with_param("filename", file_name);
         }
-        let response = request.send()?;
+        let response = request.trace_send()?;
         check_error(&response)?;
         Ok(json::from_str(response.as_str()?)?)
     }

--- a/src/api/trace_send.rs
+++ b/src/api/trace_send.rs
@@ -9,13 +9,9 @@ impl TraceSend for Request {
         // minreq::Request unfortunately exposes none of its contents, so we
         // can't conveniently print them here
         let result = self.send();
-        let trace = if cfg!(debug_assertions) {
-            match std::env::var("CSES_CLI_TRACE") {
-                Ok(val) => !val.is_empty(),
-                Err(_) => false,
-            }
-        } else {
-            false
+        let trace = match std::env::var("CSES_CLI_TRACE") {
+            Ok(val) => !val.is_empty(),
+            Err(_) => false,
         };
         if trace {
             if let Ok(response) = &result {

--- a/src/api/trace_send.rs
+++ b/src/api/trace_send.rs
@@ -1,0 +1,30 @@
+use minreq::{Error, Request, Response};
+
+pub trait TraceSend {
+    fn trace_send(self) -> Result<Response, Error>;
+}
+
+impl TraceSend for Request {
+    fn trace_send(self) -> Result<Response, Error> {
+        // minreq::Request unfortunately exposes none of its contents, so we
+        // can't conveniently print them here
+        let result = self.send();
+        let trace = if cfg!(debug_assertions) {
+            match std::env::var("CSES_CLI_TRACE") {
+                Ok(val) => !val.is_empty(),
+                Err(_) => false,
+            }
+        } else {
+            false
+        };
+        if trace {
+            if let Ok(response) = &result {
+                eprintln!("Response: {}", response.status_code);
+                if let Ok(body) = response.as_str() {
+                    eprintln!("{}", body);
+                }
+            }
+        }
+        result
+    }
+}

--- a/src/api/trace_send.rs
+++ b/src/api/trace_send.rs
@@ -1,18 +1,14 @@
 use minreq::{Error, Request, Response};
 
 pub trait TraceSend {
-    fn trace_send(self) -> Result<Response, Error>;
+    fn trace_send(self, trace: bool) -> Result<Response, Error>;
 }
 
 impl TraceSend for Request {
-    fn trace_send(self) -> Result<Response, Error> {
+    fn trace_send(self, trace: bool) -> Result<Response, Error> {
         // minreq::Request unfortunately exposes none of its contents, so we
         // can't conveniently print them here
         let result = self.send();
-        let trace = match std::env::var("CSES_CLI_TRACE") {
-            Ok(val) => !val.is_empty(),
-            Err(_) => false,
-        };
         if trace {
             if let Ok(response) = &result {
                 eprintln!("Response: {}", response.status_code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,10 @@ fn run() -> anyhow::Result<()> {
     };
 
     let command = Command::from_command_line()?;
-    let api = if !test {
-        CsesHttpApi::default()
+    let api = if let Ok(url) = std::env::var("CSES_API_URL") {
+        CsesHttpApi::new(url)
     } else {
-        CsesHttpApi::new(String::from("http://127.0.0.1:4011"))
+        CsesHttpApi::default()
     };
     let storage = FileStorage::new(test)?;
     let filesystem = ConcreteFilesystem::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,13 +34,14 @@ fn run() -> anyhow::Result<()> {
         Ok(val) => !val.is_empty(),
         Err(_) => false,
     };
+    let trace = match std::env::var("CSES_CLI_TRACE") {
+        Ok(val) => !val.is_empty(),
+        Err(_) => false,
+    };
+    let url = std::env::var("CSES_API_URL").unwrap_or_else(|_| "http://127.0.0.1:4010".to_owned());
 
     let command = Command::from_command_line()?;
-    let api = if let Ok(url) = std::env::var("CSES_API_URL") {
-        CsesHttpApi::new(url)
-    } else {
-        CsesHttpApi::default()
-    };
+    let api = CsesHttpApi::new(url, trace);
     let storage = FileStorage::new(test)?;
     let filesystem = ConcreteFilesystem::default();
     let resources: Resources<DefaultResources> = Resources {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -12,6 +12,7 @@ pub static TESTS: [fn()] = [..];
 pub fn command() -> Command {
     let mut command = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     command.env("CSES_CLI_TEST", "true");
+    command.env("CSES_API_URL", "http://127.0.0.1:4011");
     command
 }
 


### PR DESCRIPTION
- The environment variable `CSES_API_URL` overrides the root of API request URLs. This should not include a trailing slash.
- The environment variable `CSES_CLI_TRACE` prints API responses for debug purposes